### PR TITLE
melee unit targeting

### DIFF
--- a/Assets/Audio.meta
+++ b/Assets/Audio.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: c798c4145d47677488c53ec05cab7103
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Cutscenes/SpecificStages.meta
+++ b/Assets/Scripts/Cutscenes/SpecificStages.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: ddb6cacd66da6174e956b331e09d6a3d
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Units/MeleeUnit.cs
+++ b/Assets/Scripts/Units/MeleeUnit.cs
@@ -47,13 +47,17 @@ namespace Units {
 		}
 
 		public override List<Unit> getTargets(int myX, int myY, Battlefield battlefield, Character character) {
-			//TODO: create specific implementation for melee units
-			List<Unit> targets = new List<Unit>();
-			List<Coord> tiles = getValidMoves(myX, myY, battlefield);
-			foreach(Coord tile in tiles) {
-				Unit targetUnit = battlefield.units[tile.x, tile.y];
-				if(targetUnit != null && targetUnit.getCharacter(battlefield) != character) {
-					targets.Add(targetUnit);
+
+			for (int x = myX - 1; x <= myX + 1;x++) {
+				for (int y = myY - 1; y <= myY + 1; y++) {
+					try {
+						Unit targetUnit = battlefield.units[x, y];
+						if(targetUnit != null && targetUnit.getCharacter(battlefield) != character) {
+							targets.Add(targetUnit);
+						}
+					} catch (IndexOutOfRangeException) {
+					//do nothing, we just tried to check for a tile at a location outside the bounds of the map
+					}
 				}
 			}
 			return targets;

--- a/Assets/Scripts/Units/MeleeUnit.cs
+++ b/Assets/Scripts/Units/MeleeUnit.cs
@@ -49,17 +49,18 @@ namespace Units {
 		public override List<Unit> getTargets(int myX, int myY, Battlefield battlefield, Character character) {
 
 			List<Unit> targets = new List<Unit>();
+			List<Coord> tiles = new List<Coord>();
+			tiles.Add(new Coord(myX+1,myY));
+			tiles.Add(new Coord(myX-1,myY));
+			tiles.Add(new Coord(myX,myY+1));
+			tiles.Add(new Coord(myX,myY-1));
 
-			for (int x = myX - 1; x <= myX + 1;x++) {
-				for (int y = myY - 1; y <= myY + 1; y++) {
-					try {
-						Unit targetUnit = battlefield.units[x, y];
+			foreach (Coord tile in tiles) {
+				if(!(tile.x < 0 || tile.y < 0 || tile.x >= battlefield.map.GetLength(0) || tile.y >= battlefield.map.GetLength(1))) {
+					Unit targetUnit = battlefield.units[tile.x, tile.y];
 						if(targetUnit != null && targetUnit.getCharacter(battlefield) != character) {
 							targets.Add(targetUnit);
 						}
-					} catch (IndexOutOfRangeException) {
-					//do nothing, we just tried to check for a tile at a location outside the bounds of the map
-					}
 				}
 			}
 			return targets;

--- a/Assets/Scripts/Units/MeleeUnit.cs
+++ b/Assets/Scripts/Units/MeleeUnit.cs
@@ -48,6 +48,8 @@ namespace Units {
 
 		public override List<Unit> getTargets(int myX, int myY, Battlefield battlefield, Character character) {
 
+			List<Unit> targets = new List<Unit>();
+
 			for (int x = myX - 1; x <= myX + 1;x++) {
 				for (int y = myY - 1; y <= myY + 1; y++) {
 					try {

--- a/Assets/UI/Buffs.meta
+++ b/Assets/UI/Buffs.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: b6608981ce1224045b44f0eb651abdc0
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Implemented specific version of getTargets() for melee units. Melee units can now only attack enemies that are in the 8 neighboring tiles.